### PR TITLE
Fix 'cross-database references' mis-syntax error

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -393,11 +393,11 @@ begin
         v_curr.obj_name,
         nextval(v_sequence::regclass),
         format(
-          'GRANT %s ON %I.%I.%I TO %I %s',
+          'GRANT %s (%I) ON %I.%I TO %I %s',
           privilege_type,
+          column_name,
           table_schema,
           table_name,
-          column_name,
           grantee,
           case
             when is_grantable = 'YES'
@@ -426,11 +426,11 @@ begin
         v_curr.obj_name,
         nextval(v_sequence::regclass),
         format(
-          'GRANT %s ON %I.%I.%I to %I %s',
+          'GRANT %s (%I) ON %I.%I to %I %s',
           privilege_type,
+          column_name,
           table_schema,
           table_name,
-          column_name,
           grantee,
           case
             when is_grantable = 'YES'


### PR DESCRIPTION
I think this must just have been a typo, since it's been documented as
`UPDATE (column) ON table` in all versions since column specificity was
introduced in 9.0:
  https://www.postgresql.org/docs/9.0/sql-grant.html
  https://www.postgresql.org/docs/13.0/sql-grant.html (current)

(and nothing older, or 9, is supported.)

Confusingly, instead of a syntax error, pg complains that
'cross-database references are not implemented', presumably
misinterpreting:

    schema.table.column

as an attempt to do:

    db.schema.table

which isn't allowed, but also isn't what we're trying to do.

This commit fixes the error when restoring DDL by using the documented
syntax of:

    (column) ON schema.table