### PR TITLE
Drop temporary views after use

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -769,6 +769,12 @@ begin
     v_sequence
   );
 
+  raise debug 'Dropping temp view: _role_table_grants';
+  drop view _role_table_grants;
+
+  raise debug 'Dropping temp view: _role_column_grants';
+  drop view _role_column_grants;
+
   if v_verbose then
     reset client_min_messages;
   end if;


### PR DESCRIPTION
Fixes #17 by  dropping temporary views _role_table_grants and _role_column_grants at the end of the function.