### PR TITLE
Add support for MAINTAIN privilege

### DIFF
--- a/ddl.sql
+++ b/ddl.sql
@@ -508,7 +508,8 @@ begin
             case when acl ~ 'd|d\*' then 'DELETE' end,
             case when acl ~ 'D|D\*' then 'TRUNCATE' end,
             case when acl ~ 'x|x\*' then 'REFERENCES' end,
-            case when acl ~ 't|t\*' then 'TRIGGER' end
+            case when acl ~ 't|t\*' then 'TRIGGER' end,
+            case when acl ~ 'm|m\*' then 'MAINTAIN' end
           ]::text[]) as privilege_type,
           unnest(ARRAY[
             case when acl ~ 'a\*' then 'YES' else 'NO' end,
@@ -517,7 +518,8 @@ begin
             case when acl ~ 'd\*' then 'YES' else 'NO' end,
             case when acl ~ 'D\*' then 'YES' else 'NO' end,
             case when acl ~ 'x\*' then 'YES' else 'NO' end,
-            case when acl ~ 't\*' then 'YES' else 'NO' end
+            case when acl ~ 't\*' then 'YES' else 'NO' end,
+            case when acl ~ 'm\*' then 'YES' else 'NO' end
           ]::text[]) as is_grantable
         from (
           select


### PR DESCRIPTION
Postgres 17 introduced the [MAINTAIN privilege](https://www.postgresql.org/docs/current/ddl-priv.html#DDL-PRIV-MAINTAIN), which allows VACUUM, ANALYZE, CLUSTER, REFRESH MATERIALIZED VIEW, REINDEX, and LOCK TABLE on a relation.